### PR TITLE
Use more lodash test methods and support more types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # pretty-format [![Travis build status](http://img.shields.io/travis/thejameskyle/pretty-format.svg?style=flat)](https://travis-ci.org/thejameskyle/pretty-format)
 
-Stringify any JavaScript value.
+> Stringify any JavaScript value.
 
-![](http://i.imgur.com/UM7RQza.png)
+Supports objects, arrays (and typed arrays and array buffers), arguments,
+booleans, dates, errors, functions, `Infinity`, maps, `NaN`, `null`, numbers,
+regular expressions, sets, strings, symbols, `undefined`, weak maps, weak
+sets, and circular data structures.
 
 ## Installation
 
@@ -15,19 +18,30 @@ $ npm install pretty-format
 ```js
 var prettyFormat = require('pretty-format');
 
-var obj = { foo: 1 };
-obj.self = obj;
+var obj = { property: {} };
+obj.circularReference = obj;
 obj[Symbol('foo')] = 'foo';
-obj.bar = new Map();
-obj.bar.set('baz', 'bat');
+obj.map = new Map();
+obj.map.set('prop', 'value');
+obj.array = [1, NaN, Infinity];
 
 console.log(prettyFormat(obj));
-// Object {
-//   "foo": 1,
-//   "self": [Circular],
-//   "bar": Map {
-//     "baz" => "bat"
-//   },
-//   Symbol(foo): "foo"
-// }
+```
+
+**Result:**
+
+```js
+Object {
+  "property": Object {},
+  "circularReference": [Circular],
+  "map": Map {
+    "prop" => "value"
+  },
+  "array": Array [
+    1,
+    NaN,
+    Infinity
+  ],
+  Symbol(foo): "foo"
+}
 ```

--- a/index.js
+++ b/index.js
@@ -72,6 +72,26 @@ prettyFormat.reset = reset;
 
 module.exports = prettyFormat;
 
+function printArray(array) {
+  var body = '';
+
+  if (array.length) {
+    body += '\n';
+
+    for (var i = 0; i < array.length; i++) {
+      body += indentLines(prettyFormat(array[i]));
+
+      if (i < array.length - 1) {
+        body += ',\n';
+      }
+    }
+
+    body += '\n';
+  }
+
+  return '[' + body + ']';
+}
+
 /**
  * @public
  * @class Arguments
@@ -82,7 +102,7 @@ Type.Arguments = new Type({
   test: _.isArguments,
 
   print: function(val) {
-    return 'Arguments ' + Type.Array.print(val);
+    return 'Arguments ' + printArray(val);
   }
 });
 
@@ -93,26 +113,12 @@ Type.Arguments = new Type({
  * @memberOf Type
  */
 Type.Array = new Type({
-  test: _.isArray,
+  test: function(val) {
+    return _.isArray(val) || _.isTypedArray(val) || _.isArrayBuffer(val);
+  },
 
   print: function(val) {
-    var result = '[';
-
-    if (val.length) {
-      result += '\n';
-
-      for (var i = 0; i < val.length; i++) {
-        result += indentLines(prettyFormat(val[i]));
-
-        if (i < val.length - 1) {
-          result += ',\n';
-        }
-      }
-
-      result += '\n';
-    }
-
-    return result + ']';
+    return val.constructor.name + ' ' + printArray(val);
   }
 });
 
@@ -210,7 +216,6 @@ Type.Infinity = new Type({
   }
 });
 
-
 /**
  * @public
  * @class Map
@@ -218,9 +223,7 @@ Type.Infinity = new Type({
  * @memberOf Type
  */
 Type.Map = new Type({
-  test: function(val) {
-    return Object.prototype.toString.call(val) === '[object Map]';
-  },
+  test: _.isMap,
 
   print: function(val) {
     var result = 'Map {';
@@ -353,9 +356,7 @@ Type.RegExp = new Type({
  * @memberOf Type
  */
 Type.Set = new Type({
-  test: function(val) {
-    return Object.prototype.toString.call(val) === '[object Set]';
-  },
+  test: _.isSet,
 
   print: function(val) {
     var result = 'Set {';
@@ -405,9 +406,7 @@ Type.String = new Type({
  * @memberOf Type
  */
 Type.Symbol = new Type({
-  test: function(val) {
-    return val && val.toString && SYMBOL_REGEXP.test(val.toString());
-  },
+  test: _.isSymbol,
 
   print: function(val) {
     return Symbol.prototype.toString.call(val).replace(SYMBOL_REGEXP, 'Symbol($1)');
@@ -428,12 +427,37 @@ Type.Undefined = new Type({
   }
 });
 
+Type.WeakMap = new Type({
+  test: _.isWeakMap,
+
+  print: function() {
+    return 'WeakMap {}';
+  }
+});
+
+Type.WeakMap = new Type({
+  test: _.isWeakMap,
+
+  print: function() {
+    return 'WeakMap {}';
+  }
+});
+
+Type.WeakSet = new Type({
+  test: _.isWeakSet,
+
+  print: function() {
+    return 'WeakSet {}';
+  }
+});
+
 Type.all = [
   Type.Circular,
 
   Type.Arguments,
   Type.Array,
   Type.Boolean,
+  Type.Date,
   Type.Error,
   Type.Function,
   Type.Infinity,
@@ -446,7 +470,8 @@ Type.all = [
   Type.String,
   Type.Symbol,
   Type.Undefined,
-  Type.Date,
+  Type.WeakMap,
+  Type.WeakSet,
 
   Type.Object
 ];

--- a/test.js
+++ b/test.js
@@ -69,13 +69,17 @@ describe('Type', function() {
     typeTests('Array', Type.Array, {
       test: [
         { value: [], pass: true },
+        { value: new Uint32Array(2), pass: true },
+        { value: new ArrayBuffer(2), pass: true },
         { value: {}, pass: false },
         { value: 'foo', pass: false }
       ],
       print: [
-        { input: [], output: '[]' },
-        { input: [1], output: '[\n  1\n]' },
-        { input: [[1, 2]], output: '[\n  [\n    1,\n    2\n  ]\n]' }
+        { input: [], output: 'Array []' },
+        { input: [1], output: 'Array [\n  1\n]' },
+        { input: new Uint32Array(2), output: 'Uint32Array [\n  0,\n  0\n]' },
+        { input: new ArrayBuffer(2), output: 'ArrayBuffer []' },
+        { input: [[1, 2]], output: 'Array [\n  Array [\n    1,\n    2\n  ]\n]' }
       ]
     });
   }());
@@ -113,7 +117,7 @@ describe('Type', function() {
       ],
       print: [
         { input: obj, output: 'Object {\n  "obj": [Circular]\n}', both: false },
-        { input: arr, output: '[\n  [Circular]\n]', both: false }
+        { input: arr, output: 'Array [\n  [Circular]\n]', both: false }
       ]
     });
   }());
@@ -173,6 +177,7 @@ describe('Type', function() {
       test: [
         { value: map1, pass: true },
         { value: map2, pass: true },
+        { value: new WeakMap(), pass: false },
         { value: false, pass: false },
         { value: {}, pass: false }
       ],
@@ -288,6 +293,7 @@ describe('Type', function() {
       test: [
         { value: set1, pass: true },
         { value: set2, pass: true },
+        { value: new WeakSet(), pass: false },
         { value: false, pass: false },
         { value: {}, pass: false }
       ],
@@ -334,6 +340,32 @@ describe('Type', function() {
       ],
       print: [
         { input: undefined, output: 'undefined' }
+      ]
+    });
+  }());
+
+  (function() {
+    typeTests('WeakMap', Type.WeakMap, {
+      test: [
+        { value: new WeakMap(), pass: true },
+        { value: new Map(), pass: false },
+        { value: {}, pass: false }
+      ],
+      print: [
+        { input: new WeakMap(), output: 'WeakMap {}' }
+      ]
+    });
+  }());
+
+  (function() {
+    typeTests('WeakSet', Type.WeakSet, {
+      test: [
+        { value: new WeakSet(), pass: true },
+        { value: new Set(), pass: false },
+        { value: {}, pass: false }
+      ],
+      print: [
+        { input: new WeakSet(), output: 'WeakSet {}' }
       ]
     });
   }());


### PR DESCRIPTION
Adds support for:

- ArrayBuffer
- Typed Arrays (Uint8Array, Uint16Array, etc.)
- WeakMaps/WeakSets

And now that we're using an updated version of lodash, I've started using more `_.is*` methods, which likely cover more things.

cc @cpojer 