### PR TITLE
Fix for sorted props in nested components

### DIFF
--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -335,5 +335,28 @@ describe('prettyFormat()', function() {
         '<Mouse\n  customProp={\n    Object {\n      "one": "1",\n      "two": 2\n    }\n  }\n  onclick={[Function anonymous]}>\n  HELLO\n  <Mouse\n    customProp={\n      Object {\n        "one": "1",\n        "two": 2\n      }\n    }\n    onclick={[Function anonymous]}>\n    HELLO\n    <Mouse />\n    CIAO\n  </Mouse>\n  CIAO\n</Mouse>'
       );
     });
+
+    it('should sort props in nested components', function() {
+      assertPrintedJSX(
+        React.createElement('Mouse', {
+            zeus: 'kentaromiura watched me fix this',
+            abc: {
+              one: '1',
+              two: 2
+            }
+          },
+          React.createElement('Mouse', {
+              xyz: 123,
+              acbd: {
+                one: '1',
+                two: 2
+              }
+            },
+            'NESTED'
+          )
+        ),
+        '<Mouse\n  abc={\n    Object {\n      "one": "1",\n      "two": 2\n    }\n  }\n  zeus="kentaromiura watched me fix this">\n  <Mouse\n    acbd={\n      Object {\n        "one": "1",\n        "two": 2\n      }\n    }\n    xyz={123}>\n    NESTED\n  </Mouse>\n</Mouse>'
+      );
+    });
   });
 });

--- a/plugins/ReactTestComponent.js
+++ b/plugins/ReactTestComponent.js
@@ -7,7 +7,7 @@ function printChildren(children, print, indent) {
 }
 
 function printProps(props, print, indent) {
-  return Object.keys(props).map(function(name) {
+  return Object.keys(props).sort().map(function(name) {
     var prop = props[name];
     var printed = print(prop);
 


### PR DESCRIPTION
This is required for the new `jest-snapshot` feature, in order to get consistent rendered props in snapshots.