### PR TITLE
print `Object.create(null)`

### DIFF
--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -254,6 +254,10 @@ describe('prettyFormat()', function() {
     }), 'class Foo');
   });
 
+  it('should print objects with no constructor', function() {
+    assert.equal(prettyFormat(Object.create(null)), 'Object {}');
+  });
+
   describe('ReactTestComponent plugin', function() {
     var Mouse = React.createClass({
       getInitialState: function() {

--- a/index.js
+++ b/index.js
@@ -141,7 +141,8 @@ function printMap(val, indent, prevIndent, refs, maxDepth, currentDepth, plugins
 }
 
 function printObject(val, indent, prevIndent, refs, maxDepth, currentDepth, plugins) {
-  var result = val.constructor.name + ' {';
+  var constructor = val.constructor ?  val.constructor.name + ' ' : 'Object ';
+  var result = constructor + '{';
   var keys = Object.keys(val).sort();
   var symbols = getSymbols(val);
 


### PR DESCRIPTION
it was failing on objects with no constructor.
```js
> console.log(require('pretty-format')(global))
TypeError: Cannot read property 'name' of undefined
```