### PR TITLE
Add ReactElement plugin

### DIFF
--- a/plugins/ReactElement.js
+++ b/plugins/ReactElement.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const printString = require('../printString');
+
+const reactElement = Symbol.for('react.element');
+
+function traverseChildren(opaqueChildren, cb) {
+  if (Array.isArray(opaqueChildren)) {
+    opaqueChildren.forEach(child => traverseChildren(child, cb));
+  } else if (opaqueChildren != null && opaqueChildren !== false) {
+    cb(opaqueChildren);
+  }
+}
+
+function printChildren(flatChildren, print, indent) {
+  return flatChildren.map(node => {
+    if (typeof node === 'object') {
+      return printElement(node, print, indent);
+    } else if (typeof node === 'string') {
+      return printString(node);
+    } else {
+      return print(node);
+    }
+  }).join('\n');
+}
+
+function printProps(props, print, indent) {
+  return Object.keys(props).sort().map(name => {
+    if (name === 'children') {
+      return '';
+    }
+
+    const prop = props[name];
+    let printed = print(prop);
+
+    if (typeof prop !== 'string') {
+      if (printed.indexOf('\n') !== -1) {
+        printed = '{\n' + indent(indent(printed) + '\n}');
+      } else {
+        printed = '{' + printed + '}';
+      }
+    }
+
+    return '\n' + indent(name + '=') + printed;
+  }).join('');
+}
+
+function printElement(element, print, indent) {
+  let result = '<' + element.type;
+  result += printProps(element.props, print, indent);
+
+  const opaqueChildren = element.props.children;
+  if (opaqueChildren) {
+    let flatChildren = [];
+    traverseChildren(opaqueChildren, child => {
+      flatChildren.push(child);
+    });
+    const children = printChildren(flatChildren, print, indent);
+    result += '>\n' + indent(children) + '\n</' + element.type + '>';
+  } else {
+    result += ' />';
+  }
+
+  return result;
+}
+
+module.exports = {
+  test(object) {
+    return object && object.$$typeof === reactElement;
+  },
+  print(val, print, indent) {
+    return printElement(val, print, indent);
+  }
+};

--- a/plugins/ReactTestComponent.js
+++ b/plugins/ReactTestComponent.js
@@ -5,7 +5,7 @@ const printString = require('../printString');
 const reactTestInstance = Symbol.for('react.test.json');
 
 function printChildren(children, print, indent) {
-  return children.map(child => printElement(child, print, indent)).join('\n');
+  return children.map(child => printInstance(child, print, indent)).join('\n');
 }
 
 function printProps(props, print, indent) {
@@ -25,22 +25,22 @@ function printProps(props, print, indent) {
   }).join('');
 }
 
-function printElement(element, print, indent) {
-  if (typeof element == 'number') {
-    return print(element);
-  } else if (typeof element === 'string') {
-    return printString(element);
+function printInstance(instance, print, indent) {
+  if (typeof instance == 'number') {
+    return print(instance);
+  } else if (typeof instance === 'string') {
+    return printString(instance);
   }
 
-  let result = '<' + element.type;
+  let result = '<' + instance.type;
 
-  if (element.props) {
-    result += printProps(element.props, print, indent);
+  if (instance.props) {
+    result += printProps(instance.props, print, indent);
   }
 
-  if (element.children) {
-    const children = printChildren(element.children, print, indent);
-    result += '>\n' + indent(children) + '\n</' + element.type + '>';
+  if (instance.children) {
+    const children = printChildren(instance.children, print, indent);
+    result += '>\n' + indent(children) + '\n</' + instance.type + '>';
   } else {
     result += ' />';
   }
@@ -53,6 +53,6 @@ module.exports = {
     return object && object.$$typeof === reactTestInstance;
   },
   print(val, print, indent) {
-    return printElement(val, print, indent);
+    return printInstance(val, print, indent);
   }
 };


### PR DESCRIPTION
Should fix https://github.com/facebook/jest/issues/1429.
Some tests are backported from https://github.com/thejameskyle/pretty-format/pull/28.

I separated plugins because they are only artificially similar.
However I kept the tests shared so we can make sure behavior is identical for shallow and snapshot testing.