### PR TITLE
Print class methods

### DIFF
--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -165,6 +165,27 @@ describe('prettyFormat()', () => {
     expect(prettyFormat(val)).toEqual('Object {\n  "a": 2,\n  "b": 1\n}');
   });
 
+  it('should print a class instance', () => {
+    const val = new class Foo {
+      constructor() {
+        this.abc = 123;
+      }
+      bar() {}
+    };
+    expect(prettyFormat(val)).toEqual('Foo {\n  "abc": 123,\n  "bar": [Function bar]\n}');
+  });
+
+  it('should print a class instance with symbol properties', () => {
+    const val = new class Foo {
+      constructor() {
+        this[Symbol('bar')] = 'abc';
+      }
+      [Symbol('foo')]() {}
+      bar() {}
+    };
+    expect(prettyFormat(val)).toEqual('Foo {\n  "bar": [Function bar],\n  Symbol(bar): "abc",\n  Symbol(foo): [Function anonymous]\n}');
+  });
+
   it('should print regular expressions from constructors', () => {
     const val = new RegExp('regexp');
     expect(prettyFormat(val)).toEqual('/regexp/');

--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -172,7 +172,7 @@ describe('prettyFormat()', () => {
       }
       bar() {}
     };
-    expect(prettyFormat(val)).toEqual('Foo {\n  "abc": 123,\n  "bar": [Function bar]\n}');
+    expect(prettyFormat(val)).toEqual('Foo {\n  "abc": 123,\n  bar() {}\n}');
   });
 
   it('should print a class instance with symbol properties', () => {
@@ -183,7 +183,7 @@ describe('prettyFormat()', () => {
       [Symbol('foo')]() {}
       bar() {}
     };
-    expect(prettyFormat(val)).toEqual('Foo {\n  "bar": [Function bar],\n  Symbol(bar): "abc",\n  Symbol(foo): [Function anonymous]\n}');
+    expect(prettyFormat(val)).toEqual('Foo {\n  bar() {},\n  [Symbol(bar)]: "abc",\n  [Symbol(foo)]() {}\n}');
   });
 
   it('should print regular expressions from constructors', () => {

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const SYMBOL_REGEXP = /^Symbol\((.*)\)(.*)$/;
 const NEWLINE_REGEXP = /\n/ig;
 
 const getSymbols = Object.getOwnPropertySymbols || (obj => []);
+const isClass = func => typeof func === 'function' && /^class\s/.test(Function.prototype.toString.call(func));
 
 function isToStringedArrayType(toStringed) {
   return (
@@ -144,7 +145,15 @@ function printObject(val, indent, prevIndent, refs, maxDepth, currentDepth, plug
   const constructor = val.constructor ?  val.constructor.name + ' ' : 'Object ';
   let result = constructor + '{';
   let keys = Object.keys(val).sort();
-  const symbols = getSymbols(val);
+  let symbols = getSymbols(val);
+
+  if (isClass(val.constructor)) {
+    const proto = Object.getPrototypeOf(val);
+    const classMethods = Object.getOwnPropertyNames(proto).filter(p => p !== 'constructor');
+
+    keys = keys.concat(classMethods);
+    symbols = symbols.concat(getSymbols(proto));
+  }
 
   if (symbols.length) {
     keys = keys


### PR DESCRIPTION
For #30 - I'm assuming it's not just methods with a Symbol as the key that should be printed - it currently doesn't print any methods.

``` js
new class Foo {
  constructor() {
    this[Symbol('bar')] = 'abc';
  }
  [Symbol('foo')]() {}
  bar() {}
};
```

```
Foo {
  Symbol(bar): "abc"
}
```

First commit adds class method printing support in the current style:

```
Foo {
  "bar": [Function bar],
  Symbol(bar): "abc",
  Symbol(foo): [Function anonymous]
}
```

Second commit then cleans up the output a little for classes only (to match the `[Symbol(foo)]() {}` example in the issue):

```
Foo {
  bar() {},
  [Symbol(bar)]: "abc",
  [Symbol(foo)]() {}
}
```
