### PR TITLE
Add option to print functions without a name.

### DIFF
--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -25,67 +25,67 @@ function assertPrintedJSX(actual, expected, opts) {
 }
 
 describe('prettyFormat()', () => {
-  it('should print empty arguments', () => {
+  it('prints empty arguments', () => {
     const val = returnArguments();
     expect(prettyFormat(val)).toEqual('Arguments []');
   });
 
-  it('should print arguments', () => {
+  it('prints arguments', () => {
     const val = returnArguments(1, 2, 3);
     expect(prettyFormat(val)).toEqual('Arguments [\n  1,\n  2,\n  3,\n]');
   });
 
-  it('should print an empty array', () => {
+  it('prints an empty array', () => {
     const val = [];
     expect(prettyFormat(val)).toEqual('Array []');
   });
 
-  it('should print an array with items', () => {
+  it('prints an array with items', () => {
     const val = [1, 2, 3];
     expect(prettyFormat(val)).toEqual('Array [\n  1,\n  2,\n  3,\n]');
   });
 
-  it('should print a typed array', () => {
+  it('prints a typed array', () => {
     const val = new Uint32Array(3);
     expect(prettyFormat(val)).toEqual('Uint32Array [\n  0,\n  0,\n  0,\n]');
   });
 
-  it('should print an array buffer', () => {
+  it('prints an array buffer', () => {
     const val = new ArrayBuffer(3);
     expect(prettyFormat(val)).toEqual('ArrayBuffer []');
   });
 
-  it('should print a nested array', () => {
+  it('prints a nested array', () => {
     const val = [[1, 2, 3]];
     expect(prettyFormat(val)).toEqual('Array [\n  Array [\n    1,\n    2,\n    3,\n  ],\n]');
   });
 
-  it('should print true', () => {
+  it('prints true', () => {
     const val = true;
     expect(prettyFormat(val)).toEqual('true');
   });
 
-  it('should print false', () => {
+  it('prints false', () => {
     const val = false;
     expect(prettyFormat(val)).toEqual('false');
   });
 
-  it('should print an error', () => {
+  it('prints an error', () => {
     const val = new Error();
     expect(prettyFormat(val)).toEqual('[Error]');
   });
 
-  it('should print a typed error with a message', () => {
+  it('prints a typed error with a message', () => {
     const val = new TypeError('message');
     expect(prettyFormat(val)).toEqual('[TypeError: message]');
   });
 
-  it('should print a function constructor', () => {
+  it('prints a function constructor', () => {
     const val = new Function();
     expect(prettyFormat(val)).toEqual('[Function anonymous]');
   });
 
-  it('should print an anonymous function', () => {
+  it('prints an anonymous function', () => {
     const val = () => {};
     const formatted = prettyFormat(val);
     // Node 6.5 infers function names
@@ -95,167 +95,174 @@ describe('prettyFormat()', () => {
     ).toBeTruthy();
   });
 
-  it('should print a named function', () => {
+  it('prints a named function', () => {
     const val = function named() {};
     expect(prettyFormat(val)).toEqual('[Function named]');
   });
 
-  it('should print Infinity', () => {
+  it('can customize function names', () => {
+    const val = function named() {};
+    expect(prettyFormat(val, {
+      printFunctionName: false,
+    })).toEqual('[Function]');
+  });
+
+  it('prints Infinity', () => {
     const val = Infinity;
     expect(prettyFormat(val)).toEqual('Infinity');
   });
 
-  it('should print -Infinity', () => {
+  it('prints -Infinity', () => {
     const val = -Infinity;
     expect(prettyFormat(val)).toEqual('-Infinity');
   });
 
-  it('should print an empty map', () => {
+  it('prints an empty map', () => {
     const val = new Map();
     expect(prettyFormat(val)).toEqual('Map {}');
   });
 
-  it('should print a map with values', () => {
+  it('prints a map with values', () => {
     const val = new Map();
     val.set('prop1', 'value1');
     val.set('prop2', 'value2');
     expect(prettyFormat(val)).toEqual('Map {\n  "prop1" => "value1",\n  "prop2" => "value2",\n}');
   });
 
-  it('should print a map with non-string keys', () => {
+  it('prints a map with non-string keys', () => {
     const val = new Map();
     val.set({ prop: 'value' }, { prop: 'value' });
     expect(prettyFormat(val)).toEqual('Map {\n  Object {\n    "prop": "value",\n  } => Object {\n    "prop": "value",\n  },\n}');
   });
 
-  it('should print NaN', () => {
+  it('prints NaN', () => {
     const val = NaN;
     expect(prettyFormat(val)).toEqual('NaN');
   });
 
-  it('should print null', () => {
+  it('prints null', () => {
     const val = null;
     expect(prettyFormat(val)).toEqual('null');
   });
 
-  it('should print a number', () => {
+  it('prints a number', () => {
     const val = 123;
     expect(prettyFormat(val)).toEqual('123');
   });
 
-  it('should print a date', () => {
+  it('prints a date', () => {
     const val = new Date(10e11);
     expect(prettyFormat(val)).toEqual('2001-09-09T01:46:40.000Z');
   });
 
-  it('should print an empty object', () => {
+  it('prints an empty object', () => {
     const val = {};
     expect(prettyFormat(val)).toEqual('Object {}');
   });
 
-  it('should print an object with properties', () => {
+  it('prints an object with properties', () => {
     const val = { prop1: 'value1', prop2: 'value2' };
     expect(prettyFormat(val)).toEqual('Object {\n  "prop1": "value1",\n  "prop2": "value2",\n}');
   });
 
-  it('should print an object with properties and symbols', () => {
+  it('prints an object with properties and symbols', () => {
     const val = { prop: 'value1' };
     val[Symbol('symbol1')] = 'value2';
     val[Symbol('symbol2')] = 'value3';
     expect(prettyFormat(val)).toEqual('Object {\n  "prop": "value1",\n  Symbol(symbol1): "value2",\n  Symbol(symbol2): "value3",\n}');
   });
 
-  it('should print an object with sorted properties', () => {
+  it('prints an object with sorted properties', () => {
     const val = { b: 1, a: 2 };
     expect(prettyFormat(val)).toEqual('Object {\n  "a": 2,\n  "b": 1,\n}');
   });
 
-  it('should print regular expressions from constructors', () => {
+  it('prints regular expressions from constructors', () => {
     const val = new RegExp('regexp');
     expect(prettyFormat(val)).toEqual('/regexp/');
   });
 
-  it('should print regular expressions from literals', () => {
+  it('prints regular expressions from literals', () => {
     const val = /regexp/ig;
     expect(prettyFormat(val)).toEqual('/regexp/gi');
   });
 
-  it('should print an empty set', () => {
+  it('prints an empty set', () => {
     const val = new Set();
     expect(prettyFormat(val)).toEqual('Set {}');
   });
 
-  it('should print a set with values', () => {
+  it('prints a set with values', () => {
     const val = new Set();
     val.add('value1');
     val.add('value2');
     expect(prettyFormat(val)).toEqual('Set {\n  "value1",\n  "value2",\n}');
   });
 
-  it('should print a string', () => {
+  it('prints a string', () => {
     const val = 'string';
     expect(prettyFormat(val)).toEqual('"string"');
   });
 
-  it('should print a string with escapes', () => {
+  it('prints a string with escapes', () => {
     expect(prettyFormat('\"-\"'), '"\\"-\\""');
     expect(prettyFormat('\\ \\\\'), '"\\\\ \\\\\\\\"');
   });
 
-  it('should print a symbol', () => {
+  it('prints a symbol', () => {
     const val = Symbol('symbol');
     expect(prettyFormat(val)).toEqual('Symbol(symbol)');
   });
 
-  it('should print undefined', () => {
+  it('prints undefined', () => {
     const val = undefined;
     expect(prettyFormat(val)).toEqual('undefined');
   });
 
-  it('should print a WeakMap', () => {
+  it('prints a WeakMap', () => {
     const val = new WeakMap();
     expect(prettyFormat(val)).toEqual('WeakMap {}');
   });
 
-  it('should print a WeakSet', () => {
+  it('prints a WeakSet', () => {
     const val = new WeakSet();
     expect(prettyFormat(val)).toEqual('WeakSet {}');
   });
 
-  it('should print deeply nested objects', () => {
+  it('prints deeply nested objects', () => {
     const val = { prop: { prop: { prop: 'value' } } };
     expect(prettyFormat(val)).toEqual('Object {\n  "prop": Object {\n    "prop": Object {\n      "prop": "value",\n    },\n  },\n}');
   });
 
-  it('should print circular references', () => {
+  it('prints circular references', () => {
     const val = {};
     val.prop = val;
     expect(prettyFormat(val)).toEqual('Object {\n  "prop": [Circular],\n}')
   });
 
-  it('should print parallel references', () => {
+  it('prints parallel references', () => {
     const inner = {};
     const val = { prop1: inner, prop2: inner };
     expect(prettyFormat(val)).toEqual('Object {\n  "prop1": Object {},\n  "prop2": Object {},\n}')
   });
 
-  it('should be able to customize indent', () => {
+  it('can customize indent', () => {
     const val = { prop: 'value' };
     expect(prettyFormat(val, { indent: 4 })).toEqual('Object {\n    "prop": "value",\n}');
   });
 
-  it('should be able to customize the max depth', () => {
+  it('can customize the max depth', () => {
     const val = { prop: { prop: { prop: {} } } };
     expect(prettyFormat(val, { maxDepth: 2 })).toEqual('Object {\n  "prop": Object {\n    "prop": [Object],\n  },\n}');
   });
 
-  it('should throw on invalid options', () => {
+  it('throws on invalid options', () => {
     expect(() => {
       prettyFormat({}, { invalidOption: true });
     }).toThrow();
   });
 
-  it('should support plugins', () => {
+  it('supports plugins', () => {
     function Foo() {};
 
     expect(prettyFormat(new Foo(), {
@@ -270,7 +277,7 @@ describe('prettyFormat()', () => {
     })).toEqual('class Foo');
   });
 
-  it('should support plugins with deeply nested arrays (#24)', () => {
+  it('supports plugins with deeply nested arrays (#24)', () => {
     const val = [[1, 2], [3, 4]];
     expect
     expect(prettyFormat(val, {
@@ -285,7 +292,7 @@ describe('prettyFormat()', () => {
     })).toEqual('1 - 2 - 3 - 4')
   });
 
-  it('should print objects with no constructor', () => {
+  it('prints objects with no constructor', () => {
     expect(prettyFormat(Object.create(null))).toEqual('Object {}');
   });
 
@@ -336,14 +343,14 @@ describe('prettyFormat()', () => {
   });
 
   describe('min', () => {
-    it('should print in min mode', () => {
+    it('prints in min mode', () => {
       const val = { prop: [1, 2, Infinity, new Set([1, 2, 3])] };
       expect(prettyFormat(val, {
         min: true
       })).toEqual('{"prop": [1, 2, Infinity, Set {1, 2, 3}]}')
     });
 
-    it('should not allow indent !== 0 in min mode', () => {
+    it('does not allow indent !== 0 in min mode', () => {
       expect(() => {
         prettyFormat(1, { min: true, indent: 1 });
       }).toThrow();
@@ -363,28 +370,28 @@ describe('prettyFormat()', () => {
       }
     });
 
-    it('should support a single element with no props or children', () => {
+    it('supports a single element with no props or children', () => {
       assertPrintedJSX(
         React.createElement('Mouse'),
         '<Mouse />'
       );
     });
 
-    it('should support a single element with no props', () => {
+    it('supports a single element with no props', () => {
       assertPrintedJSX(
         React.createElement('Mouse', null, 'Hello World'),
         '<Mouse>\n  Hello World\n</Mouse>'
       );
     });
 
-    it('should support a single element with number children', () => {
+    it('supports a single element with number children', () => {
       assertPrintedJSX(
         React.createElement('Mouse', null, 4),
         '<Mouse>\n  4\n</Mouse>'
       );
     });
 
-    it('should support a single element with mixed children', () => {
+    it('supports a single element with mixed children', () => {
       assertPrintedJSX(
         React.createElement('Mouse', null,
           [[1, null], 2, undefined, [false, [3]]]
@@ -393,35 +400,35 @@ describe('prettyFormat()', () => {
       );
     });
 
-    it('should support props with strings', () => {
+    it('supports props with strings', () => {
       assertPrintedJSX(
         React.createElement('Mouse', { style: 'color:red' }),
         '<Mouse\n  style="color:red" />'
       );
     });
 
-    it('should support props with numbers', () => {
+    it('supports props with numbers', () => {
       assertPrintedJSX(
         React.createElement('Mouse', { size: 5 }),
         '<Mouse\n  size={5} />'
       );
     });
 
-    it('should support a single element with a function prop', () => {
+    it('supports a single element with a function prop', () => {
       assertPrintedJSX(
         React.createElement('Mouse', { onclick: function onclick(){} }),
         '<Mouse\n  onclick={[Function onclick]} />'
       );
     });
 
-    it('should support a single element with a object prop', () => {
+    it('supports a single element with a object prop', () => {
       assertPrintedJSX(
         React.createElement('Mouse', { customProp: { one: '1', two: 2 } }),
         '<Mouse\n  customProp={\n    Object {\n      "one": "1",\n      "two": 2,\n    }\n  } />'
       );
     });
 
-    it('should support an element with and object prop and children', () => {
+    it('supports an element with and object prop and children', () => {
       assertPrintedJSX(
         React.createElement('Mouse', { customProp: { one: '1', two: 2 } },
           React.createElement('Mouse')
@@ -430,7 +437,7 @@ describe('prettyFormat()', () => {
       );
     });
 
-    it('should support an element with complex props and mixed children', () => {
+    it('supports an element with complex props and mixed children', () => {
       assertPrintedJSX(
         React.createElement('Mouse', { customProp: { one: '1', two: 2 }, onclick: function onclick(){} },
           'HELLO',
@@ -440,7 +447,7 @@ describe('prettyFormat()', () => {
       );
     });
 
-    it('should escape children properly', () => {
+    it('escapes children properly', () => {
       assertPrintedJSX(
         React.createElement('Mouse', null,
           '\"-\"',
@@ -451,7 +458,7 @@ describe('prettyFormat()', () => {
       );
     });
 
-    it('should support everything all together', () => {
+    it('supports everything all together', () => {
       assertPrintedJSX(
         React.createElement('Mouse', { customProp: { one: '1', two: 2 }, onclick: function onclick(){} },
           'HELLO',
@@ -466,7 +473,7 @@ describe('prettyFormat()', () => {
       );
     });
 
-    it('should sort props in nested components', () => {
+    it('sorts props in nested components', () => {
       assertPrintedJSX(
         React.createElement('Mouse', {
             zeus: 'kentaromiura watched me fix this',
@@ -489,7 +496,7 @@ describe('prettyFormat()', () => {
       );
     });
 
-    it('should support a single element with React elements as props', () => {
+    it('supports a single element with React elements as props', () => {
       assertPrintedJSX(
         React.createElement('Mouse', {
           prop: React.createElement('div')
@@ -498,7 +505,7 @@ describe('prettyFormat()', () => {
       );
     });
 
-    it('should support a single element with React elements with props', () => {
+    it('supports a single element with React elements with props', () => {
       assertPrintedJSX(
         React.createElement('Mouse', {
           prop: React.createElement('div', {foo: 'bar'})
@@ -507,7 +514,7 @@ describe('prettyFormat()', () => {
       );
     });
 
-    it('should support a single element with React elements with a child', () => {
+    it('supports a single element with React elements with a child', () => {
       assertPrintedJSX(
         React.createElement('Mouse', {
           prop: React.createElement('div', null, 'mouse')
@@ -516,7 +523,7 @@ describe('prettyFormat()', () => {
       );
     });
 
-    it('should support a single element with React elements with children', () => {
+    it('supports a single element with React elements with children', () => {
       assertPrintedJSX(
         React.createElement('Mouse', {
           prop: React.createElement('div', null, 'mouse', React.createElement('span', null, 'rat'))
@@ -525,7 +532,7 @@ describe('prettyFormat()', () => {
       );
     });
 
-    it('should support a single element with React elements with array children', () => {
+    it('supports a single element with React elements with array children', () => {
       assertPrintedJSX(
         React.createElement('Mouse', {
           prop: React.createElement('div', null,
@@ -540,7 +547,7 @@ describe('prettyFormat()', () => {
       );
     });
 
-    it('it should use the supplied line seperator for min mode', () => {
+    it('uses the supplied line seperator for min mode', () => {
       assertPrintedJSX(
         React.createElement('Mouse', { customProp: { one: '1', two: 2 }, onclick: function onclick(){} },
           'HELLO',


### PR DESCRIPTION
We are running into problems with snapshots and flaky function names through code coverage (https://github.com/facebook/jest/issues/1740) and node version updates (https://github.com/facebook/jest/pull/1717) so we decided to change snapshots to remove function names given that they often provide very little signal anyway.