### PR TITLE
Don’t manually set callToJSON.

### DIFF
--- a/index.js
+++ b/index.js
@@ -307,8 +307,6 @@ function normalizeOptions(opts) {
     result.indent = 0;
   }
 
-  result.callToJSON = !!opts.callToJSON;
-
   return result;
 }
 


### PR DESCRIPTION
I missed that the normalize function uses the defaults when available and accidentally made it so the option would always be overwritten with user input; therefore inadvertently disabling the default.