### PR TITLE
Support for Object.create(null)

### DIFF
--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -293,7 +293,7 @@ describe('prettyFormat()', () => {
   });
 
   it('prints objects with no constructor', () => {
-    expect(prettyFormat(Object.create(null))).toEqual('Object {}');
+    expect(prettyFormat(Object.create(null))).toEqual('null {}');
   });
 
   it('calls toJSON and prints its return value', () => {

--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ function printMap(val, indent, prevIndent, spacing, edgeSpacing, refs, maxDepth,
 }
 
 function printObject(val, indent, prevIndent, spacing, edgeSpacing, refs, maxDepth, currentDepth, plugins, min, callToJSON, printFunctionName) {
-  const constructor = min || !Object.getPrototypeOf(val) ? '' : (val.constructor ?  val.constructor.name + ' ' : 'Object ');
+  const constructor = min ? '' : (val.constructor ?  val.constructor.name + ' ' : 'null ');
   let result = constructor + '{';
   let keys = Object.keys(val).sort();
   const symbols = getSymbols(val);

--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ function printMap(val, indent, prevIndent, spacing, edgeSpacing, refs, maxDepth,
 }
 
 function printObject(val, indent, prevIndent, spacing, edgeSpacing, refs, maxDepth, currentDepth, plugins, min, callToJSON, printFunctionName) {
-  const constructor = min ? '' : (val.constructor ?  val.constructor.name + ' ' : 'Object ');
+  const constructor = min || !Object.getPrototypeOf(val) ? '' : (val.constructor ?  val.constructor.name + ' ' : 'Object ');
   let result = constructor + '{';
   let keys = Object.keys(val).sort();
   const symbols = getSymbols(val);


### PR DESCRIPTION
Resolving #42: Objects created through Object.create(null) will be printed as `null {}` instead of `Object {}` to distinguish them from normally created Objects.
