### PR TITLE
Add tests showing HTMLElement causing crash

### DIFF
--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -246,6 +246,11 @@ describe('prettyFormat()', () => {
     expect(prettyFormat(val)).toEqual('Object {\n  "prop1": Object {},\n  "prop2": Object {},\n}')
   });
 
+  it('prints an HTMLElement', () => {
+    const val = document.createElement('div');
+    expect(prettyFormat(val)).toEqual('not sure yet what it should equal');
+  });
+
   it('can customize indent', () => {
     const val = { prop: 'value' };
     expect(prettyFormat(val, { indent: 4 })).toEqual('Object {\n    "prop": "value",\n}');

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "perf": "node perf/test.js"
   },
   "jest": {
-    "testEnvironment": "node",
     "verbose": true
   },
   "devDependencies": {


### PR DESCRIPTION
Not for merging. Illustrates bug #44.

Unfortunately I'm not getting any helpful console output from this, just a crash.
