### PR TITLE
Fix wrong name printed in custom elements (when passed as props)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
   - "4"
-  - "5"
+  - "6"

--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -515,7 +515,7 @@ describe('prettyFormat()', () => {
     });
 
     it('supports a single element with custom React elements with props', () => {
-      function Cat() { React.createElement('div') };
+      function Cat() { return React.createElement('div') };
       assertPrintedJSX(
         React.createElement('Mouse', {
           prop: React.createElement(Cat, {foo: 'bar'})

--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -514,6 +514,16 @@ describe('prettyFormat()', () => {
       );
     });
 
+    it('supports a single element with custom React elements with props', () => {
+      const Cat = () => React.createElement('div');
+      assertPrintedJSX(
+        React.createElement('Mouse', {
+          prop: React.createElement(Cat, {foo: 'bar'})
+        }),
+        '<Mouse\n  prop={\n    <Cat\n      foo="bar" />\n  } />'
+      );
+    });
+
     it('supports a single element with React elements with a child', () => {
       assertPrintedJSX(
         React.createElement('Mouse', {

--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -515,7 +515,7 @@ describe('prettyFormat()', () => {
     });
 
     it('supports a single element with custom React elements with props', () => {
-      const Cat = () => React.createElement('div');
+      function Cat() { React.createElement('div') };
       assertPrintedJSX(
         React.createElement('Mouse', {
           prop: React.createElement(Cat, {foo: 'bar'})

--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -515,7 +515,9 @@ describe('prettyFormat()', () => {
     });
 
     it('supports a single element with custom React elements with props', () => {
-      function Cat() { return React.createElement('div') };
+      function Cat() {
+        return React.createElement('div');
+      };
       assertPrintedJSX(
         React.createElement('Mouse', {
           prop: React.createElement(Cat, {foo: 'bar'})

--- a/plugins/ReactElement.js
+++ b/plugins/ReactElement.js
@@ -46,7 +46,14 @@ function printProps(props, print, indent, opts) {
 }
 
 function printElement(element, print, indent, opts) {
-  let result = '<' + element.type;
+  let result = '<';
+  if (typeof element.type === 'string') {
+    result += element.type;
+  } else if (typeof element.type === 'function') {
+    result += element.type.displayName || element.type.name || 'Unknown';
+  } else {
+    result += 'Unknown';
+  }
   result += printProps(element.props, print, indent, opts);
 
   const opaqueChildren = element.props.children;


### PR DESCRIPTION
When printing a custom element passed as a prop to another one with the `ReactElement` plugin, the name of the former is not printed correctly:

```js
      const Cat = () => React.createElement('div');
      assertPrintedJSX(
        React.createElement('Mouse', {
          prop: React.createElement(Cat, {foo: 'bar'})
        }),
        '<Mouse\n  prop={\n    <Cat\n      foo="bar" />\n  } />'
      );
```

The above test fails, since the following is generated:

```
<Mouse\n  prop={\n    <() => React.createElement('div')\n      foo=\"bar\" />\n  } />
```

This issue is related to https://github.com/facebook/jest/issues/2037.