### PR TITLE
Clean up ref handling a little, verify HTML element printing

### DIFF
--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -243,12 +243,13 @@ describe('prettyFormat()', () => {
   it('prints parallel references', () => {
     const inner = {};
     const val = { prop1: inner, prop2: inner };
-    expect(prettyFormat(val)).toEqual('Object {\n  "prop1": Object {},\n  "prop2": Object {},\n}')
+    expect(prettyFormat(val)).toEqual('Object {\n  "prop1": Object {},\n  "prop2": [Circular],\n}')
   });
 
   it('prints an HTMLElement', () => {
     const val = document.createElement('div');
-    expect(prettyFormat(val)).toEqual('not sure yet what it should equal');
+
+    expect(prettyFormat(val, {maxDepth: 1})).toBe('HTMLDivElement {\n  Symbol(impl): [Object],\n}');
   });
 
   it('can customize indent', () => {

--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -246,6 +246,11 @@ describe('prettyFormat()', () => {
     expect(prettyFormat(val)).toEqual('Object {\n  "prop1": Object {},\n  "prop2": Object {},\n}')
   });
 
+  it('prints an HTMLElement', () => {
+    const val = document.createElement('div');
+    expect(prettyFormat(val)).toEqual('not sure yet what it should equal');
+  });
+
   it('can customize indent', () => {
     const val = { prop: 'value' };
     expect(prettyFormat(val, { indent: 4 })).toEqual('Object {\n    "prop": "value",\n}');

--- a/index.js
+++ b/index.js
@@ -204,7 +204,6 @@ function printSet(val, indent, prevIndent, spacing, edgeSpacing, refs, maxDepth,
 }
 
 function printComplexValue(val, indent, prevIndent, spacing, edgeSpacing, refs, maxDepth, currentDepth, plugins, min, callToJSON, printFunctionName) {
-  refs = refs.slice();
   if (refs.indexOf(val) > -1) {
     return '[Circular]';
   } else {
@@ -323,7 +322,7 @@ function prettyFormat(val, opts) {
   }
 
   let indent;
-  let refs;
+  let refs = [];
   const prevIndent = '';
   const currentDepth = 0;
   const spacing = opts.min ? ' ' : '\n';
@@ -331,7 +330,6 @@ function prettyFormat(val, opts) {
 
   if (opts && opts.plugins.length) {
     indent = createIndent(opts.indent);
-    refs = [];
     var pluginsResult = printPlugin(val, indent, prevIndent, spacing, edgeSpacing, refs, opts.maxDepth, currentDepth, opts.plugins, opts.min, opts.callToJSON, opts.printFunctionName);
     if (pluginsResult) return pluginsResult;
   }
@@ -340,7 +338,6 @@ function prettyFormat(val, opts) {
   if (basicResult) return basicResult;
 
   if (!indent) indent = createIndent(opts.indent);
-  if (!refs) refs = [];
   return printComplexValue(val, indent, prevIndent, spacing, edgeSpacing, refs, opts.maxDepth, currentDepth, opts.plugins, opts.min, opts.callToJSON, opts.printFunctionName);
 }
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "perf": "node perf/test.js"
   },
   "jest": {
-    "testEnvironment": "node",
     "verbose": true
   },
   "devDependencies": {


### PR DESCRIPTION
I can confirm the `[Circular]` replacement is working as expected, all the way up/down the DOM tree if the `maxDepth` is not leashed.

Supercedes #45 
Closes #44