### PR TITLE
Add escapeRegex option

### DIFF
--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -6,6 +6,7 @@ const React = require('react');
 const ReactTestComponent = require('../plugins/ReactTestComponent');
 const ReactElement = require('../plugins/ReactElement');
 const renderer = require('react/lib/ReactTestRenderer');
+const fs = require('fs');
 
 function returnArguments() {
   return arguments;
@@ -185,6 +186,22 @@ describe('prettyFormat()', () => {
   it('prints regular expressions from literals', () => {
     const val = /regexp/ig;
     expect(prettyFormat(val)).toEqual('/regexp/gi');
+  });
+  
+  it('escapes regular expressions', () => {
+    const val = /regexp\d/ig;
+    expect(prettyFormat(val, {escapeRegex: true})).toEqual('/regexp\\\\d/gi');
+  });
+  
+  it('reads escaped regular expressions from file', () => {
+    const val = /regexp\d/ig;
+    fs.writeFileSync(
+      '__tests__/regexTest', 
+      'module.exports = `' + prettyFormat(val, {escapeRegex: true}) + '`'
+    )
+    const regexFromFile = require.call(null, './regexTest');
+    expect(regexFromFile).toEqual('/regexp\\d/gi');
+    fs.unlinkSync('__tests__/regexTest');
   });
 
   it('prints an empty set', () => {

--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -6,7 +6,6 @@ const React = require('react');
 const ReactTestComponent = require('../plugins/ReactTestComponent');
 const ReactElement = require('../plugins/ReactElement');
 const renderer = require('react/lib/ReactTestRenderer');
-const fs = require('fs');
 
 function returnArguments() {
   return arguments;
@@ -191,17 +190,6 @@ describe('prettyFormat()', () => {
   it('escapes regular expressions', () => {
     const val = /regexp\d/ig;
     expect(prettyFormat(val, {escapeRegex: true})).toEqual('/regexp\\\\d/gi');
-  });
-  
-  it('reads escaped regular expressions from file', () => {
-    const val = /regexp\d/ig;
-    fs.writeFileSync(
-      '__tests__/regexTest', 
-      'module.exports = `' + prettyFormat(val, {escapeRegex: true}) + '`'
-    )
-    const regexFromFile = require.call(null, './regexTest');
-    expect(regexFromFile).toEqual('/regexp\\d/gi');
-    fs.unlinkSync('__tests__/regexTest');
   });
 
   it('prints an empty set', () => {


### PR DESCRIPTION
There was an idea from @cpojer (https://github.com/facebook/jest/issues/1606) to implement an option for escaping regular expressions. 

This PR aims to add `escapeRegex` option by applying `printString()` function for regular expressions.

Tests include a case for writing an escaped string to a file and read it with `require.call()`. `require` call _eats_ backslashes (properly rendered with `regExpToString`) resulting in Jest not being able to compare regex stored inside snapshots.

This option doesn't add any breaking changes and would help us resolve the issue.