### PR TITLE
require react-test-renderer in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ var reactTestPlugin = require('pretty-format/plugins/ReactTestComponent');
 var reactElementPlugin = require('pretty-format/plugins/ReactElement');
 
 var React = require('react');
-var renderer = require('react/lib/ReactTestRenderer');
+var renderer = require('react-test-renderer');
 
 var jsx = React.createElement('h1', null, 'Hello World');
 


### PR DESCRIPTION
When I ran the example code with react 15.4.1

> Error: Cannot find module 'react/lib/ReactTestRenderer'

but when I changed to `require('react-test-renderer')` it returns expected output.

The problem and solution were familiar because I wrote a similar require that failed a few weeks ago when I upgraded a project from react 15.3.2 to 15.4.0-rc.4

According to https://facebook.github.io/react/blog/2016/11/16/react-v15.4.0.html#separating-react-and-react-dom

> there is a possibility that you imported private APIs from react/lib/*